### PR TITLE
Update dependencies and Android build configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:2.2.6'
+    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:2.2.2'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:2.2.6'
+    implementation 'com.github.pedroSG94:rtmp-rtsp-stream-client-java:2.2.6'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.github.pedroSG94:rtmp-rtsp-stream-client-java:2.2.6'
+    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:encoder:2.2.6'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:encoder:2.2.6'
+    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:2.2.6'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,19 +2,19 @@ group 'com.app.rtmp_publisher'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.20'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:8.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
-rootProject.allprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()
@@ -27,29 +27,28 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'com.app.rtmp_publisher'
-    compileSdkVersion 33
-    buildToolsVersion "33.0.1"
+    compileSdk 35
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdk 21
     }
-    lintOptions {
+    lint {
         disable 'InvalidPackage'
     }
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.android.support:support-v4:28.0.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.9.6'
+    implementation 'androidx.annotation:annotation:1.9.1'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:2.2.6'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 }
 
-allprojects {
+rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
@@ -50,5 +50,5 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.9.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:2.2.2'
+    implementation 'com.github.pedroSG94:rtmp-rtsp-stream-client-java:2.0.0'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableSdkManagement=false
+android.disableAutomaticComponentCreation=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -278,7 +278,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.2"
+    version: "2.3.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -307,10 +307,10 @@ packages:
     dependency: "direct dev"
     description:
       name: video_player
-      sha256: "4a8c3492d734f7c39c2588a3206707a05ee80cef52e8c7f3b2078d430c84bc17"
+      sha256: "48941c8b05732f9582116b1c01850b74dbee1d8520cd7e34ad4609d6df666845"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.2"
+    version: "2.9.3"
   video_player_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  path_provider: ^2.0.13
-  video_player: ^2.9.2
+  path_provider: ^2.1.5
+  video_player: ^2.9.3
 
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Update dependencies and Android build configuration

- Upgrade Kotlin version to 1.9.22
- Update Gradle build tools to 8.6.1
- Bump compileSdk to 35 and set Java compatibility to 17
- Update dependencies in pubspec.yaml and build.gradle
- Modify Gradle properties and wrapper